### PR TITLE
Read clock ID from device property

### DIFF
--- a/Documentation/devicetree/bindings/dpll/dpll-device.yaml
+++ b/Documentation/devicetree/bindings/dpll/dpll-device.yaml
@@ -27,6 +27,11 @@ properties:
   "#size-cells":
     const: 0
 
+  clock-id:
+    description: Specifies ID of the clock that the DPLL device drives
+    $ref: /schemas/types.yaml#/definitions/uint64
+    minimum: 0
+
   dpll-types:
     description: List of DPLL channel types, one per DPLL instance.
     $ref: /schemas/types.yaml#/definitions/non-unique-string-array

--- a/drivers/dpll/zl3073x/core.c
+++ b/drivers/dpll/zl3073x/core.c
@@ -9,6 +9,8 @@
 #include <linux/math64.h>
 #include <linux/module.h>
 #include <linux/netlink.h>
+#include <linux/property.h>
+#include <linux/random.h>
 #include <linux/regmap.h>
 #include <linux/sprintf.h>
 #include <linux/string_choices.h>
@@ -866,6 +868,29 @@ zl3073x_dev_phase_meas_setup(struct zl3073x_dev *zldev, int num_channels)
 }
 
 /**
+ * zl3073x_dev_clock_id_init - initialize clock ID
+ * @zldev: pointer to zl3073x device
+ *
+ * Initializes clock ID using device property if it is provided or
+ * generates random one.
+ */
+static void
+zl3073x_dev_clock_id_init(struct zl3073x_dev *zldev)
+{
+	u64 clock_id;
+	int rc;
+
+	/* Try to read clock ID from device property */
+	rc = device_property_read_u64(zldev->dev, "clock-id", &clock_id);
+
+	/* Generate random id if the property does not exist or value is zero */
+	if (rc || !clock_id)
+		clock_id = get_random_u64();
+
+	zldev->clock_id = clock_id;
+}
+
+/**
  * zl3073x_dev_probe - initialize zl3073x device
  * @zldev: pointer to zl3073x device
  * @chip_info: chip info based on compatible
@@ -918,11 +943,8 @@ int zl3073x_dev_probe(struct zl3073x_dev *zldev,
 		FIELD_GET(GENMASK(15, 8), cfg_ver),
 		FIELD_GET(GENMASK(7, 0), cfg_ver));
 
-	/* Generate random clock ID as the device has not such property that
-	 * could be used for this purpose. A user can later change this value
-	 * using devlink.
-	 */
-	zldev->clock_id = get_random_u64();
+	/* Initialize clock ID */
+	zl3073x_dev_clock_id_init(zldev);
 
 	/* Initialize mutex for operations where multiple reads, writes
 	 * and/or polls are required to be done atomically.


### PR DESCRIPTION
The current ZL3073x firmware revisions do not provide any information
unique for the particular chip that could be use to generate clock ID
necessary for a DPLL device registration.

Currently the driver generates random clock ID during probe and a user
have and option to change this value using devlink interface.

The situation is very similar to network controllers that do not have
assigned a fixed MAC address.

The purpose of this series is to allow to specify the clock ID property
through DT. If the property is not provided then the driver will use
randomly generated value as fallback.